### PR TITLE
Handle invalid value for cache expiry time

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/ErrorHandler/AiHandleErrorAttribute.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus.Configuration/ErrorHandler/AiHandleErrorAttribute.cs
@@ -1,1 +1,12 @@
-using System;using System.Web.Mvc;using Microsoft.ApplicationInsights;namespace Microsoft.Teams.Apps.FAQPlusPlus.Configuration.ErrorHandler{    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]     public class AiHandleErrorAttribute : HandleErrorAttribute    {        public override void OnException(ExceptionContext filterContext)        {            if (filterContext != null && filterContext.HttpContext != null && filterContext.Exception != null)            {                //If customError is Off, then AI HTTPModule will report the exception                if (filterContext.HttpContext.IsCustomErrorEnabled)                {                       var ai = new TelemetryClient();                    ai.TrackException(filterContext.Exception);                }             }            base.OnException(filterContext);        }    }}
+// <copyright file="AiHandleErrorAttribute.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.Teams.Apps.FAQPlusPlus.Configuration.ErrorHandler{    using System;    using System.Web.Mvc;    using Microsoft.ApplicationInsights;
+    /// <summary>
+    /// Report unhandled errors to Application Insights
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]    public class AiHandleErrorAttribute : HandleErrorAttribute    {        /// <inheritdoc/>
+        public override void OnException(ExceptionContext filterContext)        {            if (filterContext != null && filterContext.HttpContext != null && filterContext.Exception != null)            {
+                // If customError is Off, then AI HTTPModule will report the exception
+                if (filterContext.HttpContext.IsCustomErrorEnabled)                {                    var ai = new TelemetryClient();                    ai.TrackException(filterContext.Exception);                }            }            base.OnException(filterContext);        }    }}

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/appsettings.json
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/appsettings.json
@@ -8,7 +8,7 @@
   "SearchServiceName": "",
   "SearchServiceAdminApiKey": "",
   "SearchServiceQueryApiKey": "",
-  "CacheExpiryInDays": 5,
+  "AccessCacheExpiryInDays": 5,
   "SearchIndexingIntervalInMinutes": 10,
   "ApplicationInsights": {
     "InstrumentationKey": ""


### PR DESCRIPTION
If the cache expiry time is <= 0, fallback to the default value of 5 days.
Fix setting name in appsettings.json.
Fix stylecop errors.