### PR TITLE
V nesura/adding new changes to sme facing feedback card

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/AskAnExpertCard.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/AskAnExpertCard.cs
@@ -119,7 +119,6 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
                     },
                     new AdaptiveTextBlock
                     {
-                        Weight = AdaptiveTextWeight.Bolder,
                         Text = Resource.DescriptionText,
                         Wrap = true
                     },

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/CardHelper.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/CardHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
         /// <summary>
         /// Maximum length of the user description
         /// </summary>
-        public const int DescriptionMaxDisplayLength = 200;
+        public const int DescriptionMaxDisplayLength = 500;
 
         private const string Ellipsis = "...";
 
@@ -89,7 +89,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
         /// </summary>
         /// <param name="dateTime">The date and time to format.</param>
         /// <param name="userLocalTime">The sender's local time, as determined by the local timestamp of the activity.</param>
-        /// <returns>A description string.</returns>
+        /// <returns>A datetime string.</returns>
         public static string GetFormattedDateInUserTimeZone(DateTime dateTime, DateTimeOffset? userLocalTime)
         {
             // Adaptive card on mobile has a bug where it does not support DATE and TIME, so for now we convert the date and time manually

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ShareFeedbackCard.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ShareFeedbackCard.cs
@@ -132,7 +132,6 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
                     },
                     new AdaptiveTextBlock
                     {
-                        Weight = AdaptiveTextWeight.Bolder,
                         Text = Resource.DescriptionText,
                         Wrap = true,
                     },

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/SmeFeedbackCard.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/SmeFeedbackCard.cs
@@ -32,22 +32,29 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
             {
                Body = new List<AdaptiveElement>
                {
-                   new AdaptiveFactSet
+                   new AdaptiveTextBlock()
                    {
-                       Facts = new List<AdaptiveFact>
-                       {
-                           new AdaptiveFact()
-                           {
-                               Title = Resource.RatingFactTitle,
-                               Value = GetRatingDisplayText(data.Rating),
-                           }
-                       },
+                       Text = Resource.SMEFeedbackHeaderText,
+                       Weight = AdaptiveTextWeight.Bolder,
+                       Size = AdaptiveTextSize.Medium,
                    },
-                    new AdaptiveTextBlock()
-                    {
-                        Text = string.Format(Resource.FeedbackAlertText, userDetails.Name),
-                        Wrap = true
-                    }
+                   new AdaptiveTextBlock()
+                   {
+                       Text = string.Format(Resource.FeedbackAlertText, userDetails.Name),
+                       Wrap = true,
+                   },
+                   new AdaptiveTextBlock()
+                   {
+                       Text = Resource.RatingTitle,
+                       Weight = AdaptiveTextWeight.Bolder,
+                       Wrap = true,
+                   },
+                   new AdaptiveTextBlock()
+                   {
+                       Text = GetRatingDisplayText(data.Rating),
+                       Spacing = AdaptiveSpacing.None,
+                       Wrap = true,
+                   },
                },
                Actions = new List<AdaptiveAction>
                {
@@ -62,16 +69,17 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
             // Description fact is available in the card only when user enters description text.
             if (!string.IsNullOrWhiteSpace(data.Description))
             {
-                smeFeedbackCard.Body.Add(new AdaptiveFactSet
+                smeFeedbackCard.Body.Add(new AdaptiveTextBlock()
                 {
-                    Facts = new List<AdaptiveFact>
-                    {
-                        new AdaptiveFact()
-                        {
-                            Title = Resource.DescriptionFact,
-                            Value = CardHelper.TruncateStringIfLonger(data.Description, CardHelper.DescriptionMaxDisplayLength),
-                        },
-                    }
+                    Text = Resource.DescriptionText,
+                    Weight = AdaptiveTextWeight.Bolder,
+                    Wrap = true,
+                });
+                smeFeedbackCard.Body.Add(new AdaptiveTextBlock()
+                {
+                    Text = CardHelper.TruncateStringIfLonger(data.Description, CardHelper.DescriptionMaxDisplayLength),
+                    Spacing = AdaptiveSpacing.None,
+                    Wrap = true,
                 });
             }
 

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/WelcomeCard.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/WelcomeCard.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
                     new AdaptiveTextBlock
                     {
                         HorizontalAlignment = AdaptiveHorizontalAlignment.Left,
-                        Size = AdaptiveTextSize.Small,
                         Text = welcomeText,
                         Wrap = true
                     }

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Resource.Designer.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Resource.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resource {
@@ -88,7 +88,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type your detailed question and supporting details here..
+        ///   Looks up a localized string similar to Type your detailed question and supporting details here (500 characters max).
         /// </summary>
         public static string AskAnExpertPlaceholderText {
             get {
@@ -115,7 +115,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If my answer isn&apos;t satisfactory, I&apos;ll connect you to an expert..
+        ///   Looks up a localized string similar to ...If my answer isn&apos;t satisfactory... I&apos;ll connect you to an expert..
         /// </summary>
         public static string AskAnExpertText2 {
             get {
@@ -286,7 +286,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to **{0}** has shared the feedback..
+        ///   Looks up a localized string similar to **{0}** has shared the feedback.
         /// </summary>
         public static string FeedbackAlertText {
             get {
@@ -295,7 +295,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter your feedback and supporting details here..
+        ///   Looks up a localized string similar to Enter your feedback and supporting details here (500 characters max).
         /// </summary>
         public static string FeedbackDescriptionPlaceholderText {
             get {
@@ -313,7 +313,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Feedback(*Required*).
+        ///   Looks up a localized string similar to Feedback (Required).
         /// </summary>
         public static string FeedbackRatingRequired {
             get {
@@ -340,7 +340,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can ask me a question by typing it in the chat box below and I&apos;ll either answer it or refer you to an expert..
+        ///   Looks up a localized string similar to You can ask me a question by typing it in the chat box below  I&apos;ll try my best to answer it....
         /// </summary>
         public static string FunctionCardText2 {
             get {
@@ -484,20 +484,20 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rating:.
-        /// </summary>
-        public static string RatingFactTitle {
-            get {
-                return ResourceManager.GetString("RatingFactTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Rating is mandatory.
         /// </summary>
         public static string RatingMandatoryText {
             get {
                 return ResourceManager.GetString("RatingMandatoryText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rating.
+        /// </summary>
+        public static string RatingTitle {
+            get {
+                return ResourceManager.GetString("RatingTitle", resourceCulture);
             }
         }
         
@@ -592,7 +592,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter short title here.
+        ///   Looks up a localized string similar to Enter short title here (50 characters max).
         /// </summary>
         public static string ShowCardTitleText {
             get {
@@ -624,6 +624,15 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         public static string SMEClosedStatus {
             get {
                 return ResourceManager.GetString("SMEClosedStatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Feedback.
+        /// </summary>
+        public static string SMEFeedbackHeaderText {
+            get {
+                return ResourceManager.GetString("SMEFeedbackHeaderText", resourceCulture);
             }
         }
         
@@ -790,7 +799,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Title(*Required*).
+        ///   Looks up a localized string similar to Title (Required).
         /// </summary>
         public static string TitleRequiredText {
             get {

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Resource.resx
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Properties/Resource.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AskAnExpertPlaceholderText" xml:space="preserve">
-    <value>Type your detailed question and supporting details here.</value>
+    <value>Type your detailed question and supporting details here (500 characters max)</value>
     <comment>Ask an expert placeholder text.</comment>
   </data>
   <data name="AskAnExpertText1" xml:space="preserve">
@@ -126,7 +126,7 @@
     <comment>Title of the ask an expert card.</comment>
   </data>
   <data name="AskAnExpertText2" xml:space="preserve">
-    <value>If my answer isn't satisfactory, I'll connect you to an expert.</value>
+    <value>...If my answer isn't satisfactory... I'll connect you to an expert.</value>
     <comment>Helps the user in understanding there is an expert team to connect to.</comment>
   </data>
   <data name="FeedbackText1" xml:space="preserve">
@@ -138,7 +138,7 @@
     <comment>Explains what bot does and possible questions.</comment>
   </data>
   <data name="FunctionCardText2" xml:space="preserve">
-    <value>You can ask me a question by typing it in the chat box below and I'll either answer it or refer you to an expert.</value>
+    <value>You can ask me a question by typing it in the chat box below  I'll try my best to answer it...</value>
     <comment>Suggests the user to ask question.</comment>
   </data>
   <data name="ShareFeedbackButtonText" xml:space="preserve">
@@ -150,7 +150,7 @@
     <comment>Description text is the label of description text box.</comment>
   </data>
   <data name="FeedbackDescriptionPlaceholderText" xml:space="preserve">
-    <value>Enter your feedback and supporting details here.</value>
+    <value>Enter your feedback and supporting details here (500 characters max)</value>
     <comment>Placeholder label where the user enters feedback in the text box.</comment>
   </data>
   <data name="FeedbackHeaderText" xml:space="preserve">
@@ -268,7 +268,7 @@ I am your friendly Q&amp;A bot that helps you provide support to people who inte
     <comment>Created: one of the available fact set in notification cards- created is the title for created date value.</comment>
   </data>
   <data name="ShowCardTitleText" xml:space="preserve">
-    <value>Enter short title here</value>
+    <value>Enter short title here (50 characters max)</value>
     <comment>Label text where users enters title for his question or feedback. </comment>
   </data>
   <data name="KBEntryFactTitle" xml:space="preserve">
@@ -292,7 +292,7 @@ I am your friendly Q&amp;A bot that helps you provide support to people who inte
     <comment>This text is used as title for results feedback card.</comment>
   </data>
   <data name="FeedbackAlertText" xml:space="preserve">
-    <value>**{0}** has shared the feedback.</value>
+    <value>**{0}** has shared the feedback</value>
     <comment>Text in the SME feedback card, The placeholder {0} represents the name of the person sharing the feedback. The placeholder {1} represents the feedback type.</comment>
   </data>
   <data name="ShareFeedbackTitleText" xml:space="preserve">
@@ -431,7 +431,7 @@ I am your friendly Q&amp;A bot that helps you provide support to people who inte
     <comment>Available factset in user notification and SME facing cards.</comment>
   </data>
   <data name="FeedbackRatingRequired" xml:space="preserve">
-    <value>Feedback(*Required*)</value>
+    <value>Feedback (Required)</value>
     <comment>Feedback(Required): label for the feedback rating dropdown.</comment>
   </data>
   <data name="HelpfulRatingText" xml:space="preserve">
@@ -442,8 +442,8 @@ I am your friendly Q&amp;A bot that helps you provide support to people who inte
     <value>Needs Improvement</value>
     <comment>Needs improvement: available feedback rating scale.</comment>
   </data>
-  <data name="RatingFactTitle" xml:space="preserve">
-    <value>Rating:</value>
+  <data name="RatingTitle" xml:space="preserve">
+    <value>Rating</value>
     <comment>Rating fact is used in SME facing feedback card to show the rating submitted by the user from the rating dropdown in share feedback card.</comment>
   </data>
   <data name="RatingMandatoryText" xml:space="preserve">
@@ -459,7 +459,7 @@ I am your friendly Q&amp;A bot that helps you provide support to people who inte
     <comment>Title fact is used to show the title entered by the user for his inquiry.</comment>
   </data>
   <data name="TitleRequiredText" xml:space="preserve">
-    <value>Title(*Required*)</value>
+    <value>Title (Required)</value>
     <comment>Title(Required): label of the title text box.</comment>
   </data>
   <data name="NotHelpfulRatingText" xml:space="preserve">
@@ -469,5 +469,9 @@ I am your friendly Q&amp;A bot that helps you provide support to people who inte
   <data name="ViewArticleButtonText" xml:space="preserve">
     <value>View article</value>
     <comment>The necessary string for the view article button</comment>
+  </data>
+  <data name="SMEFeedbackHeaderText" xml:space="preserve">
+    <value>Feedback</value>
+    <comment>Title text for SME facing feedback card.</comment>
   </data>
 </root>


### PR DESCRIPTION
- This PR addresses the following items:
- Modified SME facing Feedback card:  removed fact sets for most of the fields and added standard text blocks, keeping question asked fact as is.
- Added simple markdown text for welcome message in configuration info table.
- Increased the max length of user description text from 200 characters to 500 characters and the same has been added to placeholder text.
- Modified user tour carousel cards text to match with new spec.